### PR TITLE
Switch to the new optimization goal interface

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -4,7 +4,8 @@
 
 use ark_bls12_381::{Bls12_381, Fr as BlsFr};
 use ark_crypto_primitives::SNARK;
-use ark_ff::{PrimeField, UniformRand};
+use ark_ff::PrimeField;
+use ark_std::UniformRand;
 use ark_gm17::GM17;
 use ark_mnt4_298::{Fr as MNT4Fr, MNT4_298};
 use ark_mnt4_753::{Fr as MNT4BigFr, MNT4_753};
@@ -65,7 +66,7 @@ impl<F: PrimeField> ConstraintSynthesizer<F> for DummyCircuit<F> {
 
 macro_rules! gm17_prove_bench {
     ($bench_name:ident, $bench_field:ty, $bench_pairing_engine:ty) => {
-        let rng = &mut ark_ff::test_rng();
+        let rng = &mut ark_std::test_rng();
         let c = DummyCircuit::<$bench_field> {
             a: Some(<$bench_field>::rand(rng)),
             b: Some(<$bench_field>::rand(rng)),
@@ -91,7 +92,7 @@ macro_rules! gm17_prove_bench {
 
 macro_rules! gm17_verify_bench {
     ($bench_name:ident, $bench_field:ty, $bench_pairing_engine:ty) => {
-        let rng = &mut ark_ff::test_rng();
+        let rng = &mut ark_std::test_rng();
         let c = DummyCircuit::<$bench_field> {
             a: Some(<$bench_field>::rand(rng)),
             b: Some(<$bench_field>::rand(rng)),

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -5,7 +5,6 @@
 use ark_bls12_381::{Bls12_381, Fr as BlsFr};
 use ark_crypto_primitives::SNARK;
 use ark_ff::PrimeField;
-use ark_std::UniformRand;
 use ark_gm17::GM17;
 use ark_mnt4_298::{Fr as MNT4Fr, MNT4_298};
 use ark_mnt4_753::{Fr as MNT4BigFr, MNT4_753};
@@ -16,6 +15,7 @@ use ark_relations::{
     r1cs::{ConstraintSynthesizer, ConstraintSystemRef, SynthesisError},
 };
 use ark_std::ops::Mul;
+use ark_std::UniformRand;
 
 const NUM_PROVE_REPEATITIONS: usize = 10;
 const NUM_VERIFY_REPEATITIONS: usize = 50;

--- a/examples/snark-scalability/gm17.rs
+++ b/examples/snark-scalability/gm17.rs
@@ -28,7 +28,8 @@
 use csv;
 
 // For randomness (during paramgen and proof generation)
-use ark_ff::{test_rng, One};
+use ark_ff::One;
+use ark_std::test_rng;
 
 // For benchmarking
 use std::{

--- a/src/constraints.rs
+++ b/src/constraints.rs
@@ -478,7 +478,7 @@ mod test {
     use ark_crypto_primitives::snark::constraints::SNARKGadget;
     use ark_crypto_primitives::snark::{CircuitSpecificSetupSNARK, SNARK};
     use ark_ec::PairingEngine;
-    use ark_ff::{test_rng, Field, UniformRand};
+    use ark_ff::{Field, UniformRand};
     use ark_mnt4_298::{
         constraints::PairingVar as MNT4PairingVar, Fr as MNT4Fr, MNT4_298 as MNT4PairingEngine,
     };
@@ -490,6 +490,7 @@ mod test {
         r1cs::{ConstraintSynthesizer, ConstraintSystem, ConstraintSystemRef, SynthesisError},
     };
     use ark_std::ops::MulAssign;
+    use ark_std::test_rng;
 
     #[derive(Copy, Clone)]
     struct Circuit<F: Field> {

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -1,7 +1,10 @@
 use ark_ec::{msm::FixedBaseMSM, PairingEngine, ProjectiveCurve};
 use ark_ff::{Field, One, PrimeField, UniformRand, Zero};
 use ark_poly::{EvaluationDomain, GeneralEvaluationDomain};
-use ark_relations::r1cs::{ConstraintSynthesizer, ConstraintSystem, Result as R1CSResult, SynthesisError, SynthesisMode, OptimizationGoal};
+use ark_relations::r1cs::{
+    ConstraintSynthesizer, ConstraintSystem, OptimizationGoal, Result as R1CSResult,
+    SynthesisError, SynthesisMode,
+};
 use ark_std::{cfg_into_iter, cfg_iter, vec::Vec};
 
 use rand::Rng;

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -1,9 +1,7 @@
 use ark_ec::{msm::FixedBaseMSM, PairingEngine, ProjectiveCurve};
 use ark_ff::{Field, One, PrimeField, UniformRand, Zero};
 use ark_poly::{EvaluationDomain, GeneralEvaluationDomain};
-use ark_relations::r1cs::{
-    ConstraintSynthesizer, ConstraintSystem, Result as R1CSResult, SynthesisError, SynthesisMode,
-};
+use ark_relations::r1cs::{ConstraintSynthesizer, ConstraintSystem, Result as R1CSResult, SynthesisError, SynthesisMode, OptimizationGoal};
 use ark_std::{cfg_into_iter, cfg_iter, vec::Vec};
 
 use rand::Rng;
@@ -49,6 +47,7 @@ where
 
     let setup_time = start_timer!(|| "GrothMaller17::Generator");
     let cs = ConstraintSystem::new_ref();
+    cs.set_optimization_goal(OptimizationGoal::Constraints);
     cs.set_mode(SynthesisMode::Setup);
 
     // Synthesize the circuit.
@@ -57,7 +56,7 @@ where
     end_timer!(synthesis_time);
 
     let lc_time = start_timer!(|| "Inlining LCs");
-    cs.inline_all_lcs();
+    cs.finalize();
     end_timer!(lc_time);
 
     let num_inputs = cs.num_instance_variables();

--- a/src/prover.rs
+++ b/src/prover.rs
@@ -9,7 +9,7 @@ use ark_std::{cfg_into_iter, vec::Vec};
 
 use crate::{r1cs_to_sap::R1CStoSAP, Proof, ProvingKey};
 
-use ark_relations::r1cs::{ConstraintSynthesizer, ConstraintSystem, SynthesisError};
+use ark_relations::r1cs::{ConstraintSynthesizer, ConstraintSystem, SynthesisError, OptimizationGoal};
 
 /// Create a zero-knowledge GrothMaller17 proof.
 #[inline]
@@ -47,13 +47,16 @@ where
     let prover_time = start_timer!(|| "GrothMaller17::Prover");
     let cs = ConstraintSystem::new_ref();
 
+    // Set the optimization goal
+    cs.set_optimization_goal(OptimizationGoal::Constraints);
+
     // Synthesize the circuit.
     let synthesis_time = start_timer!(|| "Constraint synthesis");
     circuit.generate_constraints(cs.clone())?;
     end_timer!(synthesis_time);
 
     let lc_time = start_timer!(|| "Inlining LCs");
-    cs.inline_all_lcs();
+    cs.finalize();
     end_timer!(lc_time);
 
     let witness_map_time = start_timer!(|| "R1CS to SAP witness map");

--- a/src/prover.rs
+++ b/src/prover.rs
@@ -9,7 +9,9 @@ use ark_std::{cfg_into_iter, vec::Vec};
 
 use crate::{r1cs_to_sap::R1CStoSAP, Proof, ProvingKey};
 
-use ark_relations::r1cs::{ConstraintSynthesizer, ConstraintSystem, SynthesisError, OptimizationGoal};
+use ark_relations::r1cs::{
+    ConstraintSynthesizer, ConstraintSystem, OptimizationGoal, SynthesisError,
+};
 
 /// Create a zero-knowledge GrothMaller17 proof.
 #[inline]

--- a/src/test.rs
+++ b/src/test.rs
@@ -40,7 +40,7 @@ mod bls12_377 {
     use crate::{
         create_random_proof, generate_random_parameters, prepare_verifying_key, verify_proof,
     };
-    use ark_ff::{test_rng, UniformRand};
+    use ark_std::{test_rng, UniformRand};
 
     use ark_bls12_377::{Bls12_377, Fr};
     use core::ops::MulAssign;
@@ -83,7 +83,7 @@ mod cp6_782 {
         create_random_proof, generate_random_parameters, prepare_verifying_key, verify_proof,
     };
 
-    use ark_ff::{test_rng, UniformRand};
+    use ark_std::{test_rng, UniformRand};
 
     use ark_cp6_782::{Fr, CP6_782};
 

--- a/tests/mimc.rs
+++ b/tests/mimc.rs
@@ -34,7 +34,8 @@ use std::time::{Duration, Instant};
 // Bring in some tools for using pairing-friendly curves
 // We're going to use the BLS12-377 pairing-friendly elliptic curve.
 use ark_bls12_377::{Bls12_377, Fr};
-use ark_ff::{test_rng, Field};
+use ark_ff::Field;
+use ark_std::test_rng;
 
 // We'll use these interfaces to construct our circuit.
 use ark_relations::{


### PR DESCRIPTION
As the title. This PR uses the new interface for optimization: (1) setting an optimization goal and (2) calling finalize instead of inline_all_lcs before converting the R1CS system to a matrix.