### PR TITLE
Replace `rand` with `ark_std::rand`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,6 @@ ark-r1cs-std = { git = "https://github.com/arkworks-rs/r1cs-std", default-featur
 tracing = { version = "0.1", default-features = false, features = [ "attributes" ], optional = true }
 derivative = { version = "2.0", features = ["use_core"], optional = true }
 
-rand = { version = "0.7", default-features = false }
 rayon = { version = "1", optional = true }
 
 [dev-dependencies]

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -7,7 +7,7 @@ use ark_relations::r1cs::{
 };
 use ark_std::{cfg_into_iter, cfg_iter, vec::Vec};
 
-use rand::Rng;
+use ark_std::rand::Rng;
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,7 @@ use ark_crypto_primitives::snark::{CircuitSpecificSetupSNARK, SNARK};
 use ark_ec::PairingEngine;
 use ark_relations::r1cs::{ConstraintSynthesizer, SynthesisError};
 use ark_std::marker::PhantomData;
-use rand::RngCore;
+use ark_std::rand::RngCore;
 
 /// The SNARK of [[GrothMaller17]](https://eprint.iacr.org/2017/540).
 pub struct GM17<E: PairingEngine> {

--- a/src/prover.rs
+++ b/src/prover.rs
@@ -1,4 +1,4 @@
-use rand::Rng;
+use ark_std::rand::Rng;
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
 

--- a/tests/mimc.rs
+++ b/tests/mimc.rs
@@ -26,10 +26,10 @@
 )]
 
 // For randomness (during paramgen and proof generation)
-use rand::Rng;
+use ark_std::rand::Rng;
 
 // For benchmarking
-use std::time::{Duration, Instant};
+use ark_std::time::{Duration, Instant};
 
 // Bring in some tools for using pairing-friendly curves
 // We're going to use the BLS12-377 pairing-friendly elliptic curve.


### PR DESCRIPTION
This PR replaces the use of `rand` with the use of `ark_std::rand`.

This closes #8 