### PR TITLE
Release v0.3.0

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
+v                               ✰  Thanks for creating a PR! ✰
+v    Before hitting that submit button please review the checkboxes.
+v    If a checkbox is n/a - please still include it but + a little note why
+☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->
+
+## Description
+
+<!-- Add a description of the changes that this PR introduces and the files that
+are the most critical to review.
+-->
+
+closes: #XXXX
+
+---
+
+Before we can merge this PR, please make sure that all the following items have been
+checked off. If any of the checklist items are not applicable, please leave them but
+write a little note why.
+
+- [ ] Targeted PR against correct branch (master)
+- [ ] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
+- [ ] Wrote unit tests
+- [ ] Updated relevant documentation in the code
+- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
+- [ ] Re-reviewed `Files changed` in the Github PR explorer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# CHANGELOG
+
+## Pending
+
+### Breaking changes
+
+### Features
+
+### Improvements
+
+### Bug fixes
+
+## v0.3.0
+
+- Change dependency to version `0.3.0` of other arkworks-rs crates.
+
+## v0.2.0 (Initial release of ark-gm17)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ark-gm17"
-version = "0.2.0"
+version = "0.3.0"
 authors = [ "arkworks contributors" ]
 description = "An implementation of the Groth-Maller 2017 zkSNARK proof system"
 homepage = "https://arkworks.rs"
@@ -15,14 +15,14 @@ edition = "2018"
 ################################# Dependencies ################################
 
 [dependencies]
-ark-ff = { version = "^0.2.0", default-features = false }
-ark-ec = { version = "^0.2.0", default-features = false }
-ark-serialize = { version = "^0.2.0", default-features = false, features = [ "derive" ] }
-ark-poly = { version = "^0.2.0", default-features = false }
-ark-std = { version = "^0.2.0", default-features = false }
-ark-relations = { version = "^0.2.0", default-features = false }
-ark-crypto-primitives = { version = "^0.2.0", default-features = false }
-ark-r1cs-std = { version = "^0.2.0", default-features = false, optional = true }
+ark-ff = { version = "^0.3.0", default-features = false }
+ark-ec = { version = "^0.3.0", default-features = false }
+ark-serialize = { version = "^0.3.0", default-features = false, features = [ "derive" ] }
+ark-poly = { version = "^0.3.0", default-features = false }
+ark-std = { version = "^0.3.0", default-features = false }
+ark-relations = { version = "^0.3.0", default-features = false }
+ark-crypto-primitives = { version = "^0.3.0", default-features = false }
+ark-r1cs-std = { version = "^0.3.0", default-features = false, optional = true }
 
 tracing = { version = "0.1", default-features = false, features = [ "attributes" ], optional = true }
 derivative = { version = "2.0", features = ["use_core"], optional = true }
@@ -31,13 +31,13 @@ rayon = { version = "1", optional = true }
 
 [dev-dependencies]
 csv = { version = "1" }
-ark-bls12-381 = { version = "^0.2.0", default-features = false, features = ["curve"] }
-ark-bls12-377 = { version = "^0.2.0", default-features = false, features = ["curve"] }
-ark-cp6-782 = { version = "^0.2.0", default-features = false }
-ark-mnt4-298 = { version = "^0.2.0", default-features = false, features = ["r1cs", "curve"] }
-ark-mnt6-298 = { version = "^0.2.0", default-features = false, features = ["r1cs"] }
-ark-mnt4-753 = { version = "^0.2.0", default-features = false, features = ["r1cs", "curve"] }
-ark-mnt6-753 = { version = "^0.2.0", default-features = false, features = ["r1cs"] }
+ark-bls12-381 = { version = "^0.3.0", default-features = false, features = ["curve"] }
+ark-bls12-377 = { version = "^0.3.0", default-features = false, features = ["curve"] }
+ark-cp6-782 = { version = "^0.3.0", default-features = false }
+ark-mnt4-298 = { version = "^0.3.0", default-features = false, features = ["r1cs", "curve"] }
+ark-mnt6-298 = { version = "^0.3.0", default-features = false, features = ["r1cs"] }
+ark-mnt4-753 = { version = "^0.3.0", default-features = false, features = ["r1cs", "curve"] }
+ark-mnt6-753 = { version = "^0.3.0", default-features = false, features = ["r1cs"] }
 
 [features]
 default = ["parallel"]

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -122,12 +122,12 @@ where
     let gamma_z = zt * &gamma;
     let alpha_beta = alpha + &beta;
     let ab_gamma_z = alpha_beta * &gamma * &zt;
-    let g_gamma = g.mul(gamma.into());
-    let g_gamma_z = g.mul(gamma_z.into());
-    let h_gamma = h.mul(gamma.into());
-    let h_gamma_z = h_gamma.mul(zt.into());
-    let g_ab_gamma_z = g.mul(ab_gamma_z.into());
-    let g_gamma2_z2 = g.mul(gamma_z.square().into());
+    let g_gamma = g.mul(&gamma.into_repr());
+    let g_gamma_z = g.mul(&gamma_z.into_repr());
+    let h_gamma = h.mul(&gamma.into_repr());
+    let h_gamma_z = h_gamma.mul(&zt.into_repr());
+    let g_ab_gamma_z = g.mul(&ab_gamma_z.into_repr());
+    let g_gamma2_z2 = g.mul(&gamma_z.square().into_repr());
 
     // Compute the vector G_gamma2_z_t := Z(t) * t^i * gamma^2 * G
     let gamma2_z_t = gamma_z * &gamma;
@@ -190,8 +190,8 @@ where
 
     // Generate R1CS verification key
     let verifying_key_time = start_timer!(|| "Generate the R1CS verification key");
-    let g_alpha = g.mul(alpha.into());
-    let h_beta = h.mul(beta.into());
+    let g_alpha = g.mul(&alpha.into_repr());
+    let h_beta = h.mul(&beta.into_repr());
     end_timer!(verifying_key_time);
 
     let vk = VerifyingKey::<E> {


### PR DESCRIPTION
This PR prepares `ark-gm17` for the release of v0.3.0.

The library has no change other than bumping the versions up to v0.3.0 and fixing some code.